### PR TITLE
Fix run card times rendering

### DIFF
--- a/components/ui/cards/run-card.tsx
+++ b/components/ui/cards/run-card.tsx
@@ -44,11 +44,7 @@ export default function RunCard({
               <MapPin className="h-4 w-4" />
               <span className="text-base">{locationName}</span>
             </a>
-            <div className="flex items-center gap-2">
-              <Clock className="h-4 w-4" />
-              <span className="text-base">Last Friday of the month, 6:30 PM</span>
-            </div>
-             {times.map((item, idx) => {
+            {times.map((item, idx) => {
                 return (
                   <div key={idx} className="flex items-center gap-2">
                     <Clock className="h-4 w-4" />
@@ -56,7 +52,7 @@ export default function RunCard({
                   </div>
                 );
             })}
-            <p className="text- mt-2">{desc}</p>
+            <p className="text-sm mt-2">{desc}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix RunCard to display configured times only
- clean up run description styling

## Testing
- `npm run lint`
- `npm run build` *(fails: Expected parameter accessToken)*

------
https://chatgpt.com/codex/tasks/task_e_683f5c1950088323bd3c16103807e7bd