### PR TITLE
Simplify EventPage params

### DIFF
--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -19,8 +19,8 @@ export async function generateStaticParams() {
   }))
 }
 
-export default async function EventPage(props: { params: Promise<{ slug: string }> }) {
-  const { slug } = await props.params;
+export default async function EventPage({ params }: { params: { slug: string } }) {
+  const { slug } = params;
   const event = await getEventBySlug(slug);
 
   if (!event) {


### PR DESCRIPTION
## Summary
- adjust `EventPage` signature to accept params directly
- remove unnecessary `await` on params

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6886a537e134832395368e11b7c32191