### PR TITLE
Fix register button wrapper

### DIFF
--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -82,7 +82,7 @@ export default async function EventPage(props: { params: Promise<{ slug: string 
 
           <div className="flex flex-col sm:flex-row gap-4 p-12">
             {event.fields.registerLink && (
-              <Button size="lg" className="flex-3">
+              <Button size="lg" className="flex-3" asChild>
                 <Link href={event.fields.registerLink}>Register for this Event</Link>
               </Button>
             )}


### PR DESCRIPTION
## Summary
- wrap the event registration link with `<Button>` using `asChild`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6886a53912008323a04fd5bd9b0b7a1c