### PR TITLE
Load regular runs from Contentful

### DIFF
--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -2,7 +2,7 @@ import AddToCalendar from "@/components/add-to-calendar"
 import GpxMapWrapper from "@/components/gpx-map-wrapper"
 import { Button } from "@/components/ui/button"
 import Header from "@/components/ui/header"
-import { ContentfulImage, getAllEvents, getEventBySlug } from "@/lib/contentful"
+import { ContentfulImage, getAllEvents, getEventBySlug, getRegularRuns } from "@/lib/contentful"
 import { formatDate } from "@/lib/utils"
 import type { Asset } from "contentful"
 import { Calendar, MapPin } from "lucide-react"
@@ -15,8 +15,9 @@ export const revalidate = 3600 // Revalidate every hour
 // Generate static params for all events
 export async function generateStaticParams() {
   const events = await getAllEvents()
+  const runs = await getRegularRuns()
 
-  return events.map((event) => ({
+  return [...events, ...runs].map((event) => ({
     slug: event.fields.slug,
   }))
 }

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import Header from "@/components/ui/header"
 import { ContentfulImage, getAllEvents, getEventBySlug, getRegularRuns } from "@/lib/contentful"
 import { formatDate } from "@/lib/utils"
-import type { Asset } from "contentful"
+import { Asset } from "contentful"
 import { Calendar, MapPin } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
@@ -70,7 +70,13 @@ export default async function EventPage(props: { params: Promise<{ slug: string 
             <div className="flex flex-wrap gap-4 text-primary/90 py-6">
             <div className="flex items-center gap-2">
               <Calendar className="h-5 w-5" />
-              <span className="text-sm">{formatDate(event.fields.date)}</span>
+              {event.fields.eventType === "Regular Run" ? (
+                event.fields.times.map((time, index) => (
+                  <span key={index} className="text-sm">{time}</span>
+                ))
+              ) : (
+                <span className="text-sm">{formatDate(event.fields.date)}</span>
+              )}
             </div>
             <div className="flex items-center gap-2">
               <MapPin className="h-5 w-5" />
@@ -78,6 +84,11 @@ export default async function EventPage(props: { params: Promise<{ slug: string 
             </div>
           </div>
             <h2 className="text-xl font-semibold mb-2">Event Details</h2>
+            {event.fields.gpxFile && (
+              <div className="mb-10">
+                <GpxMapWrapper gpxUrl={`https:${(event.fields.gpxFile as Asset).fields?.file?.url ?? ''}`} />
+              </div>
+            )}
             <div className="prose max-w-none">
               <p>{event.fields.description}</p>
             </div>
@@ -89,14 +100,10 @@ export default async function EventPage(props: { params: Promise<{ slug: string 
                 <Link href={event.fields.registerLink}>Register for this Event</Link>
               </Button>
             )}
-            <AddToCalendar event={calendarEvent} />
+            {event.fields.eventType != "Regular Run" && (
+              <AddToCalendar event={calendarEvent} />
+            )}
           </div>
-
-          {event.fields.gpxFile && (
-            <div className="my-8">
-              <GpxMapWrapper gpxUrl={`https:${(event.fields.gpxFile as Asset).fields?.file?.url ?? ''}`} />
-            </div>
-          )}
         </div>
       </div>
     </div>

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -2,12 +2,11 @@ import AddToCalendar from "@/components/add-to-calendar"
 import GpxMapWrapper from "@/components/gpx-map-wrapper"
 import { Button } from "@/components/ui/button"
 import Header from "@/components/ui/header"
-import { ContentfulImage, getAllEvents, getEventBySlug, getRegularRuns } from "@/lib/contentful"
+import { getAllEvents, getEventBySlug, getRegularRuns } from "@/lib/contentful"
 import { formatDate } from "@/lib/utils"
 import type { Asset } from "contentful"
 import { Calendar, Clock, MapPin } from "lucide-react"
 import Image from "next/image"
-import Link from "next/link"
 import { notFound } from "next/navigation"
 
 export const revalidate = 3600 // Revalidate every hour
@@ -59,7 +58,7 @@ export default async function EventPage(props: { params: Promise<{ slug: string 
             {event.fields.image && (
               <div className="mb-4 rounded-md overflow-hidden">
                 <Image
-                  src={`https:${(event.fields.image as unknown as ContentfulImage).fields?.file?.url}`}
+                  src={`https:${event.fields.image?.fields?.file?.url}`}
                   alt={event.fields.title || "Event Image"}
                   width={800}
                   height={500}
@@ -84,10 +83,12 @@ export default async function EventPage(props: { params: Promise<{ slug: string 
                 <span className="text-sm">{event.fields.times.join(', ')}</span>
               </div>
             )}
-            <div className="flex items-center gap-2">
-              <MapPin className="h-5 w-5" />
-              <span>{event.fields.locationName}</span>
-            </div>
+            <a target="_blank"  href={event.fields.location ? `https://www.google.com/maps/search/?api=1&query=${event.fields.location.lat},${event.fields.location.lon}` : '#'}>
+              <div className="flex items-center gap-2">
+                <MapPin className="h-5 w-5" />
+                <span>{event.fields.locationName}</span>
+              </div>
+            </a>
           </div>
             <h2 className="text-xl font-semibold mb-2">Event Details</h2>
             {event.fields.gpxFile && (
@@ -103,7 +104,7 @@ export default async function EventPage(props: { params: Promise<{ slug: string 
           <div className="flex flex-col sm:flex-row gap-4 p-12">
             {event.fields.registerLink && (
               <Button size="lg" className="flex-3" asChild>
-                <Link href={event.fields.registerLink}>Register for this Event</Link>
+                <a target="_blank" href={event.fields.registerLink}>Register for this Event</a>
               </Button>
             )}
             {event.fields.eventType != "Regular Run" && (

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -5,7 +5,7 @@ import Header from "@/components/ui/header"
 import { ContentfulImage, getAllEvents, getEventBySlug, getRegularRuns } from "@/lib/contentful"
 import { formatDate } from "@/lib/utils"
 import type { Asset } from "contentful"
-import { Calendar, MapPin, Clock } from "lucide-react"
+import { Calendar, Clock, MapPin } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 import { notFound } from "next/navigation"
@@ -71,7 +71,7 @@ export default async function EventPage(props: { params: Promise<{ slug: string 
             <div className="flex items-center gap-2">
               <Calendar className="h-5 w-5" />
               {event.fields.eventType === "Regular Run" ? (
-                event.fields.times.map((time, index) => (
+                event.fields.times?.map((time, index) => (
                   <span key={index} className="text-sm">{time}</span>
                 ))
               ) : (

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -5,7 +5,7 @@ import Header from "@/components/ui/header"
 import { ContentfulImage, getAllEvents, getEventBySlug, getRegularRuns } from "@/lib/contentful"
 import { formatDate } from "@/lib/utils"
 import type { Asset } from "contentful"
-import { Calendar, MapPin } from "lucide-react"
+import { Calendar, MapPin, Clock } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 import { notFound } from "next/navigation"
@@ -72,6 +72,12 @@ export default async function EventPage(props: { params: Promise<{ slug: string 
               <Calendar className="h-5 w-5" />
               <span className="text-sm">{formatDate(event.fields.date)}</span>
             </div>
+            {event.fields.times && (
+              <div className="flex items-center gap-2">
+                <Clock className="h-5 w-5" />
+                <span className="text-sm">{event.fields.times.join(', ')}</span>
+              </div>
+            )}
             <div className="flex items-center gap-2">
               <MapPin className="h-5 w-5" />
               <span>{event.fields.locationName}</span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import EventCard from "@/components/ui/cards/event-card"
 import RunCard from "@/components/ui/cards/run-card"
 import Footer from "@/components/ui/footer"
 import Header from "@/components/ui/header"
-import { getUpcomingEvents } from "@/lib/contentful"
+import { ContentfulImage, getUpcomingEvents, getRegularRuns } from "@/lib/contentful"
 import Image from "next/image"
 import Link from "next/link"
 
@@ -13,6 +13,7 @@ export const revalidate = 3600 // Revalidate every hour
 export default async function Home() {
   // Fetch upcoming events from Contentful
   const events = await getUpcomingEvents(6)
+  const runs = await getRegularRuns()
   return (
     <div className="flex min-h-screen flex-col">
       {/* Header */}
@@ -93,52 +94,19 @@ export default async function Home() {
               </p>
             </div>
             <div className="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
-              <RunCard
-                image="/Monday.jpeg?height=400&width=600"
-                title="Monday pizza run"
-                subtitle="5km run with pizza"
-                desc="A relaxed 5km run trying to shake off that Monday feeling followed by a slice of half price pizza with friends."
-                locationName="Civerinos Portobello"
-                locationUrl="https://maps.app.goo.gl/ru6n6nyCLRkzNjir9"
-                times={[
-                  'Mondays, 6:30 PM',
-                ]}
-              />
-              <RunCard
-                image="/Thursday.jpeg?height=400&width=600"
-                title="Thursday social run"
-                subtitle="Trail or road? We have both!"
-                desc="We have two options for you. A 5km trail run around Holyrood or road run around Leith. Both runs start and finish at the pub, We usually head in for some food/drink and chat afterwards."
-                locationName="Old Easyway Tap"
-                locationUrl="https://maps.app.goo.gl/bBfy9HSHPaTRMQcD8"
-                times={[
-                  'Trail - Thursdays, 6:15 PM',
-                  'Road - Thursdays, 6:30 PM',
-                ]}
-              />
-              <RunCard
-                image="/Traade.jpeg?height=400&width=600"
-                title="Sunday 5km run"
-                subtitle="Coffee, Chat & Cinnamon Bun!"
-                desc="8am every Sunday we host a 5km starting and finishing at Traade Space on Portobello High Street. Coffee, pastries, and great company."
-                locationName="Traade"
-                locationUrl="https://maps.app.goo.gl/qjkYhxWiHNybDUis8"
-                times={[
-                  'Sundays, 8:00 AM',
-                ]}
-              />
-              <RunCard
-                image="/EndOfTheMonth.jpeg?height=400&width=600"
-                title="End of the Month Run"
-                subtitle="The 5 km where it all started"
-                desc="On the last Friday of the month, we meet at the Portobello Tap for a 5km run.
-                Hang out afterwards for chat and burger. This is the run that started the club and is dear to our hearts."
-                locationName="Portobello Tap"
-                locationUrl="https://maps.app.goo.gl/5zKCeTPMCoBGmS6o7"
-                times={[
-                  'Last Friday of the month, 6:30 PM',
-                ]}
-              />
+              {runs.map((run, idx) => (
+                <RunCard
+                  key={idx}
+                  image={run.fields.image ? `https:${(run.fields.image as unknown as ContentfulImage).fields.file.url}` : ''}
+                  title={run.fields.title}
+                  subtitle={run.fields.eventType}
+                  desc={run.fields.description}
+                  locationName={run.fields.locationName}
+                  locationUrl={run.fields.location ? `https://www.google.com/maps/search/?api=1&query=${run.fields.location.lat},${run.fields.location.lon}` : '#'}
+                  times={[run.fields.date]}
+                  slug={run.fields.slug}
+                />
+              ))}
             </div>
           </div>
         </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -102,7 +102,6 @@ export default async function Home() {
                   subtitle={run.fields.subtitle}
                   desc={run.fields.description}
                   locationName={run.fields.locationName}
-                  locationUrl={run.fields.location ? `https://www.google.com/maps/search/?api=1&query=${run.fields.location.lat},${run.fields.location.lon}` : '#'}
                   times={run.fields.times ?? [run.fields.date]}
                   slug={run.fields.slug}
                 />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -94,52 +94,19 @@ export default async function Home() {
               </p>
             </div>
             <div className="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
-              <RunCard
-                image="/Monday.jpeg?height=400&width=600"
-                title="Monday pizza run"
-                subtitle="5km run with pizza"
-                desc="A relaxed 5km run trying to shake off that Monday feeling followed by a slice of half price pizza with friends."
-                locationName="Civerinos Portobello"
-                locationUrl="https://maps.app.goo.gl/ru6n6nyCLRkzNjir9"
-                times={[
-                  'Mondays, 6:30 PM',
-                ]}
-              />
-              <RunCard
-                image="/Thursday.jpeg?height=400&width=600"
-                title="Thursday social run"
-                subtitle="Trail or road? We have both!"
-                desc="We have two options for you. A 5km trail run around Holyrood or road run around Leith. Both runs start and finish at the pub, We usually head in for some food/drink and chat afterwards."
-                locationName="Old Easyway Tap"
-                locationUrl="https://maps.app.goo.gl/bBfy9HSHPaTRMQcD8"
-                times={[
-                  'Trail - Thursdays, 6:15 PM',
-                  'Road - Thursdays, 6:30 PM',
-                ]}
-              />
-              <RunCard
-                image="/Traade.jpeg?height=400&width=600"
-                title="Sunday 5km run"
-                subtitle="Coffee, Chat & Cinnamon Bun!"
-                desc="8am every Sunday we host a 5km starting and finishing at Traade Space on Portobello High Street. Coffee, pastries, and great company."
-                locationName="Traade"
-                locationUrl="https://maps.app.goo.gl/qjkYhxWiHNybDUis8"
-                times={[
-                  'Sundays, 8:00 AM',
-                ]}
-              />
-              <RunCard
-                image="/EndOfTheMonth.jpeg?height=400&width=600"
-                title="End of the Month Run"
-                subtitle="The 5 km where it all started"
-                desc="On the last Friday of the month, we meet at the Portobello Tap for a 5km run.
-                Hang out afterwards for chat and burger. This is the run that started the club and is dear to our hearts."
-                locationName="Portobello Tap"
-                locationUrl="https://maps.app.goo.gl/5zKCeTPMCoBGmS6o7"
-                times={[
-                  'Last Friday of the month, 6:30 PM',
-                ]}
-              />
+              {runs.map((run, idx) => (
+                <RunCard
+                  key={idx}
+                  image={run.fields.image ? `https:${(run.fields.image as unknown as ContentfulImage).fields.file.url}` : ''}
+                  title={run.fields.title}
+                  subtitle={run.fields.subtitle}
+                  desc={run.fields.description}
+                  locationName={run.fields.locationName}
+                  locationUrl={run.fields.location ? `https://www.google.com/maps/search/?api=1&query=${(run.fields.location as unknown as ContentfulLocation).fields.lat},${(run.fields.location as unknown as ContentfulLocation).fields.lon}` : '#'}
+                  times={run.fields.times}
+                  slug={run.fields.slug}
+                />
+              ))}
             </div>
           </div>
         </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import EventCard from "@/components/ui/cards/event-card"
 import RunCard from "@/components/ui/cards/run-card"
 import Footer from "@/components/ui/footer"
 import Header from "@/components/ui/header"
-import { ContentfulImage, ContentfulLocation, getRegularRuns, getUpcomingEvents } from "@/lib/contentful"
+import { getRegularRuns, getUpcomingEvents } from "@/lib/contentful"
 import Image from "next/image"
 import Link from "next/link"
 
@@ -97,7 +97,7 @@ export default async function Home() {
               {runs.map((run, idx) => (
                 <RunCard
                   key={idx}
-                  image={run.fields.image ? `https:${(run.fields.image as unknown as ContentfulImage).fields.file.url}` : ''}
+                  image={run.fields.image.fields.file ? `https:${run.fields.image.fields.file.url}` : ''}
                   title={run.fields.title}
                   subtitle={run.fields.subtitle}
                   desc={run.fields.description}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import EventCard from "@/components/ui/cards/event-card"
 import RunCard from "@/components/ui/cards/run-card"
 import Footer from "@/components/ui/footer"
 import Header from "@/components/ui/header"
-import { ContentfulImage, getUpcomingEvents, getRegularRuns } from "@/lib/contentful"
+import { ContentfulImage, ContentfulLocation, getRegularRuns, getUpcomingEvents } from "@/lib/contentful"
 import Image from "next/image"
 import Link from "next/link"
 
@@ -99,11 +99,11 @@ export default async function Home() {
                   key={idx}
                   image={run.fields.image ? `https:${(run.fields.image as unknown as ContentfulImage).fields.file.url}` : ''}
                   title={run.fields.title}
-                  subtitle={run.fields.eventType}
+                  subtitle={run.fields.subtitle}
                   desc={run.fields.description}
                   locationName={run.fields.locationName}
-                  locationUrl={run.fields.location ? `https://www.google.com/maps/search/?api=1&query=${run.fields.location.lat},${run.fields.location.lon}` : '#'}
-                  times={[run.fields.date]}
+                  locationUrl={run.fields.location ? `https://www.google.com/maps/search/?api=1&query=${(run.fields.location as unknown as ContentfulLocation).fields.lat},${(run.fields.location as unknown as ContentfulLocation).fields.lon}` : '#'}
+                  times={run.fields.times}
                   slug={run.fields.slug}
                 />
               ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -103,7 +103,7 @@ export default async function Home() {
                   desc={run.fields.description}
                   locationName={run.fields.locationName}
                   locationUrl={run.fields.location ? `https://www.google.com/maps/search/?api=1&query=${run.fields.location.lat},${run.fields.location.lon}` : '#'}
-                  times={[run.fields.date]}
+                  times={run.fields.times ?? [run.fields.date]}
                   slug={run.fields.slug}
                 />
               ))}

--- a/components/gpx-map.tsx
+++ b/components/gpx-map.tsx
@@ -5,6 +5,15 @@ import 'leaflet/dist/leaflet.css'
 import { useEffect, useState } from 'react'
 import { MapContainer, Marker, Polyline, Popup, TileLayer } from 'react-leaflet'
 
+const markerIcon = L.icon({
+  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
+  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+})
+
 export interface GpxMapProps {
   gpxUrl: string
 }
@@ -51,10 +60,10 @@ export default function GpxMap({ gpxUrl }: GpxMapProps) {
         url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
       />
       <Polyline positions={positions} color='#FF0000' />
-      <Marker position={start} icon={L.icon({ iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png', shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png' })}>
+      <Marker position={start} icon={markerIcon}>
         <Popup>Start</Popup>
       </Marker>
-      <Marker position={end} icon={L.icon({ iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png', shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png' })}>
+      <Marker position={end} icon={markerIcon}>
         <Popup>Finish</Popup>
       </Marker>
     </MapContainer>

--- a/components/ui/cards/run-card.tsx
+++ b/components/ui/cards/run-card.tsx
@@ -8,7 +8,6 @@ interface RunCardProps {
   desc: string;
   image: string;
   locationName: string;
-  locationUrl: string;
   times: string[];
   slug: string;
 }
@@ -19,7 +18,6 @@ export default function RunCard({
   subtitle,
   desc,
   locationName,
-  locationUrl,
   times,
   slug,
 }: RunCardProps) {

--- a/components/ui/cards/run-card.tsx
+++ b/components/ui/cards/run-card.tsx
@@ -1,5 +1,6 @@
 import { Clock, MapPin } from 'lucide-react';
 import Image from 'next/image';
+import Link from 'next/link';
 
 interface RunCardProps {
   title: string;
@@ -9,6 +10,7 @@ interface RunCardProps {
   locationName: string;
   locationUrl: string;
   times: string[];
+  slug: string;
 }
 
 export default function RunCard({
@@ -19,8 +21,10 @@ export default function RunCard({
   locationName,
   locationUrl,
   times,
+  slug,
 }: RunCardProps) {
   return (
+    <Link href={`/events/${slug}`} className="h-full">
     <div className="relative overflow-hidden rounded-xl bg-card text-card-foreground shadow h-[70vh]">
       <Image
         src={image}
@@ -57,5 +61,6 @@ export default function RunCard({
         </div>
       </div>
     </div>
+    </Link>
   );
 }

--- a/components/ui/cards/run-card.tsx
+++ b/components/ui/cards/run-card.tsx
@@ -44,10 +44,10 @@ export default function RunCard({
       <div className="z-1 p-0 text-white absolute bottom-0 inset-x-0 bg-gradient-to-t from-primary via-primary to-transparent">
         <div className="p-4 pt-16 space-y-2">
           <div className="space-y-2">
-            <a className="flex items-center gap-2" href={locationUrl}>
+            <div className="flex items-center gap-2">
               <MapPin className="h-4 w-4" />
               <span className="text-base">{locationName}</span>
-            </a>
+            </div>
             {times.map((item, idx) => {
                 return (
                   <div key={idx} className="flex items-center gap-2">

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -8,6 +8,13 @@ export interface ContentfulImage {
   };
 }
 
+export interface ContentfulLocation {
+  fields: {
+    lat: string;
+    lon: string;
+  };
+}
+
 // This matches Contentful's actual return type structure
 export type EventEntry = {
   sys: {
@@ -20,7 +27,9 @@ export type EventEntry = {
   }
   fields: {
     title: string
+    subtitle: string
     date: string
+    times: string[]
     location: EntryFieldTypes.Location,
     locationName: string
     registerLink: string
@@ -44,7 +53,7 @@ if (!CONTENTFUL_SPACE_ID) {
   throw new Error("CONTENTFUL_SPACE_ID environment variable must be defined")
 }
 
-const isPreview = VERCEL_ENV === "preview"
+const isPreview = VERCEL_ENV === "preview" || "dev"
 const accessToken = isPreview
   ? CONTENTFUL_PREVIEW_ACCESS_TOKEN
   : CONTENTFUL_ACCESS_TOKEN

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -8,13 +8,6 @@ export interface ContentfulImage {
   };
 }
 
-export interface ContentfulLocation {
-  fields: {
-    lat: string;
-    lon: string;
-  };
-}
-
 // This matches Contentful's actual return type structure
 export type EventEntry = {
   sys: {
@@ -36,7 +29,7 @@ export type EventEntry = {
     description: string
     eventType: string
     slug: string
-    image: Asset,
+    image: EntryFields.AssetLink,
     gpxFile?: Asset,
   }
 }

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -1,4 +1,4 @@
-import { Asset, createClient, EntryFieldTypes } from "contentful";
+import { Asset, createClient, EntryFields } from "contentful";
 
 export interface ContentfulImage {
   fields: {
@@ -29,8 +29,8 @@ export type EventEntry = {
     title: string
     subtitle: string
     date: string
-    times: string[]
-    location: EntryFieldTypes.Location,
+    times?: string[],
+    location: EntryFields.Location,
     locationName: string
     registerLink: string
     description: string
@@ -38,7 +38,6 @@ export type EventEntry = {
     slug: string
     image: Asset,
     gpxFile?: Asset,
-    times?: string[],
   }
 }
 

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -70,6 +70,7 @@ export async function getUpcomingEvents(limit = 6): Promise<EventEntry[]> {
       limit,
       // Only fetch events that are today or in the future
       "fields.date[gte]": new Date().toISOString().split("T")[0],
+      "fields.eventType[ne]": "Regular Run", // Exclude regular runs
       include: 3,
     })
 
@@ -87,6 +88,7 @@ export async function getAllEvents() {
       content_type: "eventEntry", // Use your actual content type ID here
       order: ["fields.date"], // Correct syntax for ordering
       limit: 100,
+      "fields.eventType[ne]": "Regular Run", // Exclude regular runs
       include: 3,
     })
 
@@ -111,12 +113,31 @@ export async function getAllEventsThisYear() {
       include: 3,
       "fields.date[gte]": todayISOString, // Only events from today onwards
       "fields.date[lte]": yearEnd, // Only events before the end of this year
+      "fields.eventType[ne]": "Regular Run", // Exclude regular runs
     });
 
     return response.items as unknown as EventEntry[] || []
   } catch (error) {
     console.error("Error fetching events from Contentful:", error)
     return [];
+  }
+}
+
+// Fetch regular run events from Contentful
+export async function getRegularRuns(): Promise<EventEntry[]> {
+  try {
+    const response = await contentfulClient.getEntries({
+      content_type: "eventEntry",
+      order: ["fields.date"],
+      "fields.eventType": "Regular Run",
+      limit: 10,
+      include: 3,
+    })
+
+    return response.items as unknown as EventEntry[]
+  } catch (error) {
+    console.error("Error fetching regular runs from Contentful:", error)
+    return []
   }
 }
 

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -29,6 +29,7 @@ export type EventEntry = {
     slug: string
     image: Asset,
     gpxFile?: Asset,
+    times?: string[],
   }
 }
 


### PR DESCRIPTION
## Summary
- read regular run events from Contentful
- exclude regular runs when listing normal events
- link RunCard to event pages
- include regular runs in event page params

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6886b1f7347c8323bbcf9d4f29ca0e4b